### PR TITLE
GAWB-3691 Initial database setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,12 @@ jobs:
     docker:
       # primary container
       - image: ansingh7115/avram
-        environment:
-          TEST_JDBC_URL: jdbc:postgresql://127.0.0.1:5432/avram
-          TEST_DB_PASSWORD: avram
 
       # database container
       - image: circleci/postgres:9.6-alpine-ram
         environment:
           POSTGRES_USER: avram
-          POSTGRES_PASSWORD: avram
+          POSTGRES_PASSWORD: test
           POSTGRES_DB: avram
 
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,18 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
+      # primary container
       - image: ansingh7115/avram
+        environment:
+          TEST_JDBC_URL: jdbc:postgresql://127.0.0.1:5432/avram
+          TEST_DB_PASSWORD: avram
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
+      # database container
+      - image: circleci/postgres:9.6-alpine-ram
+        environment:
+          POSTGRES_USER: avram
+          POSTGRES_PASSWORD: avram
+          POSTGRES_DB: avram
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         environment:
           POSTGRES_USER: avram
           POSTGRES_PASSWORD: test
-          POSTGRES_DB: avram
+          POSTGRES_DB: testdb
 
     working_directory: ~/repo
 

--- a/Database.md
+++ b/Database.md
@@ -1,0 +1,100 @@
+# PostgreSQL on Google Cloud SQL
+
+## Instance parameters
+
+* Location: ??? For development, I'm starting with the default parameters.
+* Machine type: ??? For development, I'm starting with a minimal instance based on the default parameters.
+* Automatic backups: Enabled unless/until we find a need for a different backup solution.
+* Availability: Will probably use high availability for production. Single zone for non-production because high availability costs twice as much.
+* Authorized networks: None (for now)
+* Database flags: None (for now)
+* Maintenance schedule: Must select something. Maintenance will start during the window but is not guaranteed to finish within the window.
+
+After creation, change SSL setting to require SSL connections
+ 
+> Instance details > "SSL" tab > "Allow only SSL connections" button
+
+## Connecting
+
+https://cloud.google.com/sql/docs/postgres/external-connection-methods
+
+### App Engine
+
+An App Engine application deployed in the same project as the Cloud SQL instance needs no special setup to allow connections to the database when using the recommended Google Cloud SQL JDBC socket factory (see below), and the connection is secure/encrypted. However, the local dev server does not have the same privilege so additional steps need to be taken. There are a few options:
+
+* Google Cloud SQL JDBC socket factory <--- ***selected***
+* Pre-authorized IP addresses
+* Google Cloud SQL Proxy (not investigated for App Engine)
+
+#### Google Cloud SQL JDBC socket factory
+
+https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory
+
+Effectively the same as using the Cloud SQL Proxy (https://cloud.google.com/sql/docs/postgres/sql-proxy) without the need for a separate process.
+
+Must enable Cloud SQL Admin API for the project.
+
+Uses Application Default Credentials (ADC) (https://cloud.google.com/docs/authentication/production) which come from either:
+
+* an environment variable with the location of a JSON service account key file
+* the default service account for the deployment environment (Compute Engine, Kubernetes Engine, App Engine, Cloud Functions) or the Cloud SDK application-default credentials (`glcoud auth application-default login`)
+
+Pros:
+
+* Can connect from any IP address, not just the Broad network
+* Connection is automatically encrypted without additional setup
+* Can connect to SSL-only database without manually setting up a client certificate
+* Same config as recommended connection for App Engine application
+
+Cons:
+
+* Access is dependent solely on secret keys which could accidentally leak (but are centrally authorized via IAM & admin in cloud console)
+
+#### ~~Pre-authorized IP Addresses~~
+
+Whitelist IP addresses in cloud console. Client needs only DB credentials; no ADC credentials required.
+
+Pros:
+
+* No need to set up ADC credentials on client
+* Centralized control over allowed trusted networks
+
+Cons:
+
+* Must be on a known network
+* Must set up client SSL certificates for encrypted connections
+* Config is different than recommended for App Engine; must use different strategies for different environments or use more complicated config for App Engine deploys (effectively treating it as an external application (https://cloud.google.com/sql/docs/postgres/connect-external-app))
+
+### Interactive
+
+#### `psql`
+
+Just like for App Engine dev server connections, one option is pre-authorized IP addresses.
+
+`psql "host=[INSTANCE_IP] sslmode=disable dbname=avram user=avram"`
+
+Alternately, there's the Google Cloud SQL Proxy (https://cloud.google.com/sql/docs/postgres/sql-proxy) which is an external process that establishes a secure connection between the client machine and the Cloud SQL instance. This takes some extra setup but is quicker for establishing the connection.
+
+```shell
+# leave this running in one terminal
+$ ./cloud_sql_proxy -instances=broad-avram-dev:us-central1:avram=tcp:5432 -credential_file=[PATH_TO_JSON]
+
+# run psql in a separate terminal
+$ psql "host=127.0.0.1 sslmode=disable dbname=avram user=avram"
+```
+
+We should be able to simplify this process by bundling the proxy and a script in a docker image.
+
+#### ~~`gcloud` (via Cloud Shell or local)~~
+
+From the cloud console, you can click a button to open an interactive session in Google Cloud Console which simply uses `gcloud sql connect`. This can also be done from a local workstation, i.e.:
+
+`gcloud --project broad-avram-dev sql connect avram --user=avram`
+
+This temporarily whitelists the cloud shell or workstation IP to allow connection (this does appear in the Authorization tab in cloud console). Whitelisting takes some time (> 30 seconds) which is inconvenient. This connection also requires that non-SSL connections be allowed which is not desirable.
+
+## SSL
+
+We want to use SSL for all connections, even to dev databases. As Albano said, "no excuse not to use it anymore nowadays." Google Cloud SQL Proxy takes care of this for us and is the recommended (and easiest) way to set up a database connection, both from a deployed App Engine application and local development instances.
+
+Note: There are _many_ examples of JDBC connection strings out there, including those from Google (https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/appengine-java8/cloudsql-postgres/src/main/webapp/WEB-INF/appengine-web.xml) (https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/blob/master/examples/postgres/appengine-standard-java8/src/main/webapp/WEB-INF/appengine-web.xml) that use the _wrong_ parameter name of `useSSL` for enabling SSL connections. They get away with it because they're setting it to `false` anyway. The `useSSL` parameter is for the MySQL JDBC driver. The PostgreSQL JDBC driver uses `ssl`. Also, there doesn't seem to be an analogous `requireSSL` parameter as there is for MySQL. `ssl=true` in PostgreSQL is equivalent to `useSSL=true&requireSSL=true` in MySQL.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ Entity Service
 
 
 
+## Running tests
+From avram root:
+```
+$ docker/run-postgres.sh start
+$ sbt clean compile test
+$ docker/run-postgres.sh stop
+```

--- a/build.sbt
+++ b/build.sbt
@@ -15,11 +15,6 @@ javaOptions in appengineDevServer in Compile ++= Seq(
   "-Duse_jetty9_runtime=true",
   "-D--enable_all_permissions=true")
 
-appengineDataNucleusSettings
-
-appenginePersistenceApi in appengineEnhance in Compile := "JDO"
-
-
 // When JAVA_OPTS are specified in the environment, they are usually meant for the application
 // itself rather than sbt, but they are not passed by default to the application, which is a forked
 // process. This passes them through to the "re-start" command, which is probably what a developer

--- a/docker/run-postgres.sh
+++ b/docker/run-postgres.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# The CloudSQL console simply states "PostgreSQL 5.6" so we may not match the minor version number
+POSTGRES_VERSION=9.6
+start() {
+    echo "attempting to remove old $CONTAINER container..."
+    docker rm -f $CONTAINER || echo "docker rm failed. nothing to rm."
+
+    # start up PostgreSQL
+    echo "starting up postgres container..."
+    docker run --name $CONTAINER -e POSTGRES_USER=avram -e POSTGRES_PASSWORD=test -e POSTGRES_DB=testdb -d -p 5432:5432 circleci/postgres:$POSTGRESQL_VERSION-alpine-ram
+}
+
+stop() {
+    echo "Stopping docker $CONTAINER container..."
+    docker stop $CONTAINER || echo "$CONTAINER stop failed. container already stopped."
+    docker rm -v $CONTAINER || echo "$CONTAINER rm -v failed.  container already destroyed."
+}
+
+CONTAINER=postgres-avram
+COMMAND=$1
+
+if [ ${#@} == 0 ]; then
+    echo "Usage: $0 stop|start"
+    exit 1
+fi
+
+if [ $COMMAND = "start" ]; then
+    start
+elif [ $COMMAND = "stop" ]; then
+    stop
+else
+    exit 1
+fi

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,13 +1,14 @@
 import sbt._
 
 object Dependencies {
-  val jacksonV      = "2.9.5"
-  val googleV       = "1.23.0"
-  val scalaLoggingV = "3.9.0"
-  val scalaTestV    = "3.0.5"
-  val slickV        = "3.2.3"
+  val jacksonV        = "2.9.5"
+  val googleV         = "1.23.0"
+  val scalaLoggingV   = "3.9.0"
+  val scalaTestV      = "3.0.5"
+  val slickV          = "3.2.3"
   val postgresDriverV = "42.2.4"
-  val socketFactoryV = "1.0.10"
+  val socketFactoryV  = "1.0.10"
+  val dbcpV           = "2.5.0"
 
   val workbenchUtilV    = "0.3-0e9d080"
   val workbenchModelV   = "0.11-2ce3359"
@@ -67,8 +68,7 @@ object Dependencies {
   val sam: ModuleID = "org.broadinstitute.dsde.sam-client" %% "sam" % samV
 
   val slick: ModuleID =     "com.typesafe.slick" %% "slick"                 % slickV
-  val hikariCP: ModuleID =  "com.typesafe.slick" %% "slick-hikaricp"        % slickV
-  val mysql: ModuleID =     "mysql"               % "mysql-connector-java"  % "8.0.11"
+  val dbcp2: ModuleID = "org.apache.commons" % "commons-dbcp2" % dbcpV
   val liquibase: ModuleID = "org.liquibase"       % "liquibase-core"        % "3.5.3"
 
   val postgresDriver: ModuleID = "org.postgresql" % "postgresql" % postgresDriverV
@@ -110,9 +110,9 @@ object Dependencies {
     scalaTest,
 
     slick,
-    hikariCP,
     postgresDriver,
     socketFactory,
+    dbcp2,
     liquibase,
 
     workbenchUtil,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,8 @@ object Dependencies {
   val scalaLoggingV = "3.9.0"
   val scalaTestV    = "3.0.5"
   val slickV        = "3.2.3"
+  val postgresDriverV = "42.2.4"
+  val socketFactoryV = "1.0.10"
 
   val workbenchUtilV    = "0.3-0e9d080"
   val workbenchModelV   = "0.11-2ce3359"
@@ -69,6 +71,9 @@ object Dependencies {
   val mysql: ModuleID =     "mysql"               % "mysql-connector-java"  % "8.0.11"
   val liquibase: ModuleID = "org.liquibase"       % "liquibase-core"        % "3.5.3"
 
+  val postgresDriver: ModuleID = "org.postgresql" % "postgresql" % postgresDriverV
+  val socketFactory: ModuleID = "com.google.cloud.sql" % "postgres-socket-factory" % socketFactoryV
+
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
@@ -106,7 +111,8 @@ object Dependencies {
 
     slick,
     hikariCP,
-    mysql,
+    postgresDriver,
+    socketFactory,
     liquibase,
 
     workbenchUtil,

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,8 +1,14 @@
-postgres = {
+// Properties for configuring an Apache DBCP BasicDataSource
+// along with properties for use with a slick Database
+// Note: this is _not_ appropriate for passing to a slick Database factory method
+dbcpDataSource = {
+  driverClassName = org.postgresql.Driver
   url = "jdbc:postgresql://google/avram?ssl=false&socketFactoryArg=broad-avram-dev:us-central1:avram&socketFactory=com.google.cloud.sql.postgres.SocketFactory"
-  user = "avram"
+  username = "avram"
   password = ""
-  driver = org.postgresql.Driver
-  connectionPool = disabled
-  keepAliveConnection = true
+  maxTotal = 20 // http://slick.lightbend.com/doc/3.2.3/database.html
+  slick = {
+    numThreads = 10 // https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+    queueSize = 1000 // default, but must be provided when explicitly setting numThreads
+  }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+postgres = {
+  url = "jdbc:postgresql://google/avram?ssl=false&socketFactoryArg=broad-avram-dev:us-central1:avram&socketFactory=com.google.cloud.sql.postgres.SocketFactory"
+  user = "avram"
+  password = ""
+  driver = org.postgresql.Driver
+  connectionPool = disabled
+  keepAliveConnection = true
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
@@ -4,7 +4,7 @@ import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
 
 import com.google.api.server.spi.config.{Api, ApiMethod}
 import com.typesafe.config.ConfigFactory
-import org.broadinstitute.dsde.workbench.avram.util.Logger
+import org.broadinstitute.dsde.workbench.avram.util.{DataSource, Logger}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -15,6 +15,7 @@ import scala.beans.BeanProperty
 
 case class Pong()
 case class Now(@BeanProperty message: String)
+case class DbPoolStats(@BeanProperty numActive: Int, @BeanProperty numIdle: Int, @BeanProperty totalConnections: Int)
 
 @Api(name = "avram", version = "v1", scopes = Array("https://www.googleapis.com/auth/userinfo.email"), clientIds = Array(""), audiences = Array(""))
 class AvramRoutes {
@@ -25,16 +26,25 @@ class AvramRoutes {
     Pong()
   }
 
+  // TODO: remove this endpoint when we have more meaningful ways to test database queries
   @ApiMethod(name = "now", httpMethod = "get", path = "now")
   def now: Now = {
     // Explicitly use a Future to make sure the implicit ExecutionContext is being used
     Now(Await.result(Future(fetchTimestampFromDBWithSlick()), Duration.Inf))
   }
 
+  // TODO: move/merge this endpoint into a status API
+  @ApiMethod(name = "dbPoolStats", httpMethod = "get", path = "dbPoolStats")
+  def dbPoolStats: DbPoolStats = {
+    val result = for {
+      totalConnections <- DataSource.database.run(
+        sql"select count(*) from pg_stat_activity where pid <> pg_backend_pid() and usename = current_user".as[Int])
+    } yield DbPoolStats(DataSource.ds.getNumActive, DataSource.ds.getNumIdle, totalConnections.head)
+    Await.result(result, Duration.Inf)
+  }
+
   private def fetchTimestampFromDBWithSlick(): String = {
-    // Should be using a connection pool instead of creating a connection for every request, but this works as a proof-of-concept
-    val db = Database.forConfig("postgres")
-    val now = Await.result(db.run(sql"select now()".as[String]), Duration.Inf)
+    val now = Await.result(DataSource.database.run(sql"select now()".as[String]), Duration.Inf)
     now.head
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
@@ -1,9 +1,21 @@
 package org.broadinstitute.dsde.workbench.avram.api
 
+import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
+
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.api.server.spi.config.{Api, ApiMethod}
+import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.workbench.avram.util.Logger
 
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import slick.jdbc.PostgresProfile.api._
+
+import scala.beans.BeanProperty
+
 case class Pong()
+case class Now(@BeanProperty message: String)
 
 @Api(name = "avram", version = "v1", scopes = Array("https://www.googleapis.com/auth/userinfo.email"), clientIds = Array(""), audiences = Array(""))
 class AvramRoutes {
@@ -12,5 +24,27 @@ class AvramRoutes {
   @ApiMethod(name = "ping", httpMethod = "get", path = "ping")
   def ping: Pong = {
     Pong()
+  }
+
+  @ApiMethod(name = "now", httpMethod = "get", path = "now")
+  def now: Now = {
+    // Explicitly use a Future to make sure the implicit ExecutionContext is being used
+    Now(Await.result(Future(fetchTimestampFromDBWithSlick()), Duration.Inf))
+  }
+
+  private def fetchTimestampFromDBWithSlick(): String = {
+    // Should be using a connection pool instead of creating a connection for every request, but this works as a proof-of-concept
+    val db = Database.forConfig("postgres")
+    val now = Await.result(db.run(sql"select now()".as[String]), Duration.Inf)
+    now.head
+  }
+
+  private def fetchTimestampFromDBWithJDBC(): String = {
+    val config = ConfigFactory.load().getConfig("postgres")
+    val conn: Connection = DriverManager.getConnection(config.getString("url"), config.getString("user"), config.getString("password"))
+    val statement: PreparedStatement = conn.prepareStatement("select now()")
+    val resultSet: ResultSet = statement.executeQuery()
+    resultSet.next()
+    resultSet.getString(1)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.avram.api
 
 import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.api.server.spi.config.{Api, ApiMethod}
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.workbench.avram.util.Logger

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
@@ -16,7 +16,6 @@ case class DbPoolStats(@BeanProperty numActive: Int, @BeanProperty numIdle: Int,
 
 @Api(name = "avram", version = "v1", scopes = Array("https://www.googleapis.com/auth/userinfo.email"), clientIds = Array(""), audiences = Array(""))
 class AvramRoutes {
-  val logger = new Logger
 
   @ApiMethod(name = "ping", httpMethod = "get", path = "ping")
   def ping: Pong = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramRoutes.scala
@@ -1,9 +1,6 @@
 package org.broadinstitute.dsde.workbench.avram.api
 
-import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
-
 import com.google.api.server.spi.config.{Api, ApiMethod}
-import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.workbench.avram.util.{DataSource, Logger}
 
 import scala.concurrent.duration.Duration
@@ -46,14 +43,5 @@ class AvramRoutes {
   private def fetchTimestampFromDBWithSlick(): String = {
     val now = Await.result(DataSource.database.run(sql"select now()".as[String]), Duration.Inf)
     now.head
-  }
-
-  private def fetchTimestampFromDBWithJDBC(): String = {
-    val config = ConfigFactory.load().getConfig("postgres")
-    val conn: Connection = DriverManager.getConnection(config.getString("url"), config.getString("user"), config.getString("password"))
-    val statement: PreparedStatement = conn.prepareStatement("select now()")
-    val resultSet: ResultSet = statement.executeQuery()
-    resultSet.next()
-    resultSet.getString(1)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/DataSource.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/DataSource.scala
@@ -8,15 +8,14 @@ import scala.util.Try
 
 object DataSource {
   private val config = ConfigFactory.load().getConfig("dbcpDataSource")
-  private val url = Try(sys.env("TEST_JDBC_URL")).getOrElse(config.getString("url"))
-  private val password = Try(sys.env("TEST_DB_PASSWORD")).getOrElse(config.getString("password"))
+
 
   // See https://commons.apache.org/proper/commons-dbcp/configuration.html for configuration options and defaults
   val ds = new BasicDataSource()
   ds.setDriverClassName(config.getString("driverClassName"))
-  ds.setUrl(url)
+  ds.setUrl(config.getString("url"))
   ds.setUsername(config.getString("username"))
-  ds.setPassword(password)
+  ds.setPassword(config.getString("password"))
   ds.setMaxTotal(config.getInt("maxTotal"))
 
   val database = Database.forDataSource(ds, Option(ds.getMaxTotal), AsyncExecutor("Avram Executor", config.getInt("slick.numThreads"), config.getInt("slick.queueSize")))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/DataSource.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/DataSource.scala
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsde.workbench.avram.util
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.commons.dbcp2.BasicDataSource
+import slick.jdbc.PostgresProfile.api._
+
+object DataSource {
+  private val config = ConfigFactory.load().getConfig("dbcpDataSource")
+
+  // See https://commons.apache.org/proper/commons-dbcp/configuration.html for configuration options and defaults
+  val ds = new BasicDataSource()
+  ds.setDriverClassName(config.getString("driverClassName"))
+  ds.setUrl(config.getString("url"))
+  ds.setUsername(config.getString("username"))
+  ds.setPassword(config.getString("password"))
+  ds.setMaxTotal(config.getInt("maxTotal"))
+
+  val database = Database.forDataSource(ds, Option(ds.getMaxTotal), AsyncExecutor("Avram Executor", config.getInt("slick.numThreads"), config.getInt("slick.queueSize")))
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/DataSource.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/DataSource.scala
@@ -4,15 +4,19 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.commons.dbcp2.BasicDataSource
 import slick.jdbc.PostgresProfile.api._
 
+import scala.util.Try
+
 object DataSource {
   private val config = ConfigFactory.load().getConfig("dbcpDataSource")
+  private val url = Try(sys.env("TEST_JDBC_URL")).getOrElse(config.getString("url"))
+  private val password = Try(sys.env("TEST_DB_PASSWORD")).getOrElse(config.getString("password"))
 
   // See https://commons.apache.org/proper/commons-dbcp/configuration.html for configuration options and defaults
   val ds = new BasicDataSource()
   ds.setDriverClassName(config.getString("driverClassName"))
-  ds.setUrl(config.getString("url"))
+  ds.setUrl(url)
   ds.setUsername(config.getString("username"))
-  ds.setPassword(config.getString("password"))
+  ds.setPassword(password)
   ds.setMaxTotal(config.getInt("maxTotal"))
 
   val database = Database.forDataSource(ds, Option(ds.getMaxTotal), AsyncExecutor("Avram Executor", config.getInt("slick.numThreads"), config.getInt("slick.queueSize")))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/DataSource.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/DataSource.scala
@@ -4,11 +4,8 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.commons.dbcp2.BasicDataSource
 import slick.jdbc.PostgresProfile.api._
 
-import scala.util.Try
-
 object DataSource {
   private val config = ConfigFactory.load().getConfig("dbcpDataSource")
-
 
   // See https://commons.apache.org/proper/commons-dbcp/configuration.html for configuration options and defaults
   val ds = new BasicDataSource()

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,8 +1,14 @@
-postgres = {
+// Properties for configuring an Apache DBCP BasicDataSource
+// along with properties for use with a slick Database
+// Note: this is _not_ appropriate for passing to a slick Database factory method
+dbcpDataSource = {
+  driverClassName = org.postgresql.Driver
   url = "jdbc:postgresql://google/avram?ssl=false&socketFactoryArg=broad-avram-dev:us-central1:avram&socketFactory=com.google.cloud.sql.postgres.SocketFactory"
-  user = "avram"
+  username = "avram"
   password = ""
-  driver = org.postgresql.Driver
-  connectionPool = disabled
-  keepAliveConnection = true
+  maxTotal = 20 // http://slick.lightbend.com/doc/3.2.3/database.html
+  slick = {
+    numThreads = 10 // https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+    queueSize = 1000 // default, but must be provided when explicitly setting numThreads
+  }
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,8 @@
+postgres = {
+  url = "jdbc:postgresql://google/avram?ssl=false&socketFactoryArg=broad-avram-dev:us-central1:avram&socketFactory=com.google.cloud.sql.postgres.SocketFactory"
+  user = "avram"
+  password = ""
+  driver = org.postgresql.Driver
+  connectionPool = disabled
+  keepAliveConnection = true
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -3,9 +3,9 @@
 // Note: this is _not_ appropriate for passing to a slick Database factory method
 dbcpDataSource = {
   driverClassName = org.postgresql.Driver
-  url = "jdbc:postgresql://google/avram?ssl=false&socketFactoryArg=broad-avram-dev:us-central1:avram&socketFactory=com.google.cloud.sql.postgres.SocketFactory"
+  url = "jdbc:postgresql://127.0.0.1:5432/avram"
   username = "avram"
-  password = ""
+  password = "test"
   maxTotal = 20 // http://slick.lightbend.com/doc/3.2.3/database.html
   slick = {
     numThreads = 10 // https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -3,7 +3,7 @@
 // Note: this is _not_ appropriate for passing to a slick Database factory method
 dbcpDataSource = {
   driverClassName = org.postgresql.Driver
-  url = "jdbc:postgresql://127.0.0.1:5432/avram"
+  url = "jdbc:postgresql://127.0.0.1:5432/testdb"
   username = "avram"
   password = "test"
   maxTotal = 20 // http://slick.lightbend.com/doc/3.2.3/database.html

--- a/src/test/scala/org/broadinstitute/dsde/workbench/avram/integration/PostgreSQLSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/avram/integration/PostgreSQLSpec.scala
@@ -1,7 +1,5 @@
 package org.broadinstitute.dsde.workbench.avram.integration
 
-import java.sql.{Connection, PreparedStatement, ResultSet}
-
 import slick.jdbc.PostgresProfile.api._
 import org.scalatest.FreeSpec
 
@@ -18,18 +16,6 @@ class PostgreSQLSpec extends FreeSpec {
         val action: DBIO[Seq[String]] = sql"select now()".as[String]
         val value: Seq[String] = Await.result(db.run(action), Duration.Inf)
         value foreach { v => println(s"from slick: $v") }
-      } finally db.close
-    }
-
-    "using JDBC" ignore {
-      val db = Database.forConfig("postgres")
-      try {
-        val conn: Connection = Database.forConfig("postgres").source.createConnection()
-        val statement: PreparedStatement = conn.prepareStatement("select now()")
-        val resultSet: ResultSet = statement.executeQuery()
-        resultSet.next()
-        val result = resultSet.getString(1)
-        println(s"from java: $result")
       } finally db.close
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/avram/integration/PostgreSQLSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/avram/integration/PostgreSQLSpec.scala
@@ -1,17 +1,17 @@
 package org.broadinstitute.dsde.workbench.avram.integration
 
-import slick.jdbc.PostgresProfile.api._
+import org.broadinstitute.dsde.workbench.avram.util.DataSource
 import org.scalatest.FreeSpec
+import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 
 class PostgreSQLSpec extends FreeSpec {
 
   "should fetch" - {
     "using slick" in {
-      val db = Database.forConfig("postgres")
+      val db = DataSource.database
       try {
         val action: DBIO[Seq[String]] = sql"select now()".as[String]
         val value: Seq[String] = Await.result(db.run(action), Duration.Inf)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/avram/integration/PostgreSQLSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/avram/integration/PostgreSQLSpec.scala
@@ -1,0 +1,36 @@
+package org.broadinstitute.dsde.workbench.avram.integration
+
+import java.sql.{Connection, PreparedStatement, ResultSet}
+
+import slick.jdbc.PostgresProfile.api._
+import org.scalatest.FreeSpec
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+class PostgreSQLSpec extends FreeSpec {
+
+  "should fetch" - {
+    "using slick" in {
+      val db = Database.forConfig("postgres")
+      try {
+        val action: DBIO[Seq[String]] = sql"select now()".as[String]
+        val value: Seq[String] = Await.result(db.run(action), Duration.Inf)
+        value foreach { v => println(s"from slick: $v") }
+      } finally db.close
+    }
+
+    "using JDBC" ignore {
+      val db = Database.forConfig("postgres")
+      try {
+        val conn: Connection = Database.forConfig("postgres").source.createConnection()
+        val statement: PreparedStatement = conn.prepareStatement("select now()")
+        val resultSet: ResultSet = statement.executeQuery()
+        resultSet.next()
+        val result = resultSet.getString(1)
+        println(s"from java: $result")
+      } finally db.close
+    }
+  }
+}


### PR DESCRIPTION
(Replaces #1)

This will get us started. Still need to get a connection pool set up. Also need to make the configs dynamic but I figure that will come with setting up build automation and more deployment environments. Cloud SQL instance, database, and user (all named "avram") have been created in the broad-avram-dev project. Passwords are in vault.

A working build is deployed at https://gawb3691-dot-broad-avram-dev.appspot.com/. Try https://gawb3691-dot-broad-avram-dev.appspot.com/avram/v1/now

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
