### PR TITLE
Execution context refactoring

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/Avram.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/Avram.scala
@@ -8,10 +8,8 @@ import org.broadinstitute.dsde.workbench.avram.config.{AvramConfig, DbcpDataSour
 import org.broadinstitute.dsde.workbench.avram.dataaccess.{HttpSamDao, SamDao}
 import org.broadinstitute.dsde.workbench.avram.db.DbReference
 
-import scala.concurrent.ExecutionContext
-
 /**
-  * Class providing access to all services. This merges configuration and service code to provide
+  * Object providing access to all services. This merges configuration and service code to provide
   * one-stop access for endpoint implementations.
   *
   * Service clients:
@@ -36,11 +34,11 @@ import scala.concurrent.ExecutionContext
   * (https://cloud.google.com/endpoints/docs/frameworks/java/using-guice) might give that control
   * back to us and might be worth exploring.
   */
-class Avram(implicit val executionContext: ExecutionContext) {
+object Avram {
   private val configFactory = ConfigFactory.parseResources("app.conf").withFallback(ConfigFactory.load())
   private val dbcpDataSourceConfig = configFactory.as[DbcpDataSourceConfig]("dbcpDataSource")
 
-  val database =  DbReference(dbcpDataSourceConfig)(executionContext)
+  val database =  DbReference(dbcpDataSourceConfig)
 
   val samDao: SamDao = new HttpSamDao(AvramConfig.sam.baseUrl)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/BaseEndpoint.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/BaseEndpoint.scala
@@ -8,18 +8,15 @@ import org.broadinstitute.dsde.workbench.avram.dataaccess.SamUserInfoResponse
 import org.broadinstitute.dsde.workbench.avram.db.DataAccess
 import org.broadinstitute.dsde.workbench.avram.util.ErrorResponse
 import slick.dbio.DBIO
-import slick.jdbc.TransactionIsolation
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import scala.concurrent.ExecutionContext.Implicits.global
 
 abstract class BaseEndpoint {
 
   private val log = Logger.getLogger(getClass.getName)
-  private val avram = new Avram()
-  val database = avram.database
-  private val samDao = avram.samDao
+  val database = Avram.database
+  private val samDao = Avram.samDao
   private val bearerPattern = """(?i)bearer (.*)""".r
 
   def handleAuthenticatedRequest[T]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/db/AvramComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/db/AvramComponent.scala
@@ -5,11 +5,8 @@ import java.time.Instant
 
 import slick.jdbc.JdbcProfile
 
-import scala.concurrent.ExecutionContext
-
 trait AvramComponent {
   val profile: JdbcProfile
-  implicit val executionContext: ExecutionContext
 
   protected final val dummyDate: Instant = Instant.ofEpochMilli(1000)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/db/CollectionComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/db/CollectionComponent.scala
@@ -36,13 +36,13 @@ trait CollectionComponent extends AvramComponent {
       collectionQuery += CollectionRecord(0, name, createdBy, samResource, Timestamp.from(Instant.now), None, marshalDate(None))
     }
 
-    def getCollectionByName(name: String): DBIO[Option[Collection]] = {
+    def getCollectionByName(name: String)(implicit executionContext: ExecutionContext): DBIO[Option[Collection]] = {
       collectionQuery.filter { _.name === name}.result map { recs: Seq[CollectionRecord] =>
         unmarshalCollections(recs).headOption
       }
     }
 
-    def getCollectionIdByName(name: String): DBIO[Option[Long]] = {
+    def getCollectionIdByName(name: String)(implicit executionContext: ExecutionContext): DBIO[Option[Long]] = {
       collectionQuery.filter { _.name === name }.result map { recs: Seq[CollectionRecord] =>
         val idSeq = recs map { _.id }
         idSeq.headOption

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/db/DbReference.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/db/DbReference.scala
@@ -5,12 +5,10 @@ import org.broadinstitute.dsde.workbench.avram.config.DbcpDataSourceConfig
 import slick.dbio.DBIO
 import slick.jdbc.{JdbcProfile, TransactionIsolation}
 
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.Future
 import AvramPostgresProfile.api._
 
-import scala.concurrent.duration.Duration
-
-case class DbReference(private val dataSourceConfig: DbcpDataSourceConfig)(implicit val executionContext: ExecutionContext) {
+case class DbReference(private val dataSourceConfig: DbcpDataSourceConfig) {
 
   val dataAccess = new DataAccess(AvramPostgresProfile)
 
@@ -33,7 +31,7 @@ case class DbReference(private val dataSourceConfig: DbcpDataSourceConfig)(impli
   }
 }
 
-class DataAccess(val profile: JdbcProfile)(implicit val executionContext: ExecutionContext) extends AllComponents {
+class DataAccess(val profile: JdbcProfile) extends AllComponents {
 
   def truncateAll(): DBIO[Int] = {
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/db/EntityComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/db/EntityComponent.scala
@@ -44,7 +44,7 @@ trait EntityComponent extends AvramComponent  {
       entityQuery += EntityRecord(0, name, collection, entityBody, createdBy, Timestamp.from(Instant.now), None, marshalDate(None))
     }
 
-    def getEntityByName(name: String, collectionId: Long): DBIO[Option[Entity]] = {
+    def getEntityByName(name: String, collectionId: Long)(implicit executionContext: ExecutionContext): DBIO[Option[Entity]] = {
       entityQuery
         .filter { _.name === name}
         .filter { _.collectionId === collectionId }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/avram/db/TestComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/avram/db/TestComponent.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
 
 trait TestComponent extends Matchers with ScalaFutures with AvramComponent {
   override val profile: JdbcProfile = DbSingleton.ref.dataAccess.profile
-  override implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
+  implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
   implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
   val defaultServiceAccountKeyId = ServiceAccountKeyId("123")
 


### PR DESCRIPTION
I was able to remove the execution context from the instances and instead have it be an implicit parameter for the methods that need it. We have a lot of singletons here so I think it makes sense to let the caller be more in control of the execution context anyway rather than it being baked in to the instances.

Tests pass and local deployment seems to work.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
