### PR TITLE
GAWB-3755: Add SamDao.queryAction for checking authorization

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,8 @@
 import sbt._
 
 object Dependencies {
+  val catsV           = "1.4.0"
+  val catsEffectV     = "1.0.0"
   val jacksonV        = "2.9.5"
   val googleV         = "1.23.0"
   val scalaLoggingV   = "3.9.0"
@@ -35,7 +37,8 @@ object Dependencies {
   val ravenLogback: ModuleID =   "com.getsentry.raven"        %  "raven-logback"   % "8.0.3"
   val scalaLogging: ModuleID =   "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingV
   val ficus: ModuleID =          "com.iheart"                 %% "ficus"           % "1.4.3"
-  val cats: ModuleID =           "org.typelevel"              %% "cats"            % "0.9.0"
+  val cats: ModuleID =           "org.typelevel"              %% "cats-core"       % catsV
+  val catsEffect: ModuleID =     "org.typelevel"              %% "cats-effect"     % catsEffectV
   val enumeratum: ModuleID =     "com.beachape"               %% "enumeratum"      % "1.5.13"
 
   val javaxServlet: ModuleID = "javax.servlet" % "javax.servlet-api" % javaxServletV % "provided"
@@ -73,7 +76,8 @@ object Dependencies {
   val postgresDriver: ModuleID = "org.postgresql" % "postgresql" % postgresDriverV
   val socketFactory: ModuleID = "com.google.cloud.sql" % "postgres-socket-factory" % socketFactoryV
 
-  val sttp: ModuleID = "com.softwaremill.sttp" %% "core" % sttpV
+  val sttp: ModuleID =      "com.softwaremill.sttp" %% "core"                           % sttpV
+  val sttpCats: ModuleID =  "com.softwaremill.sttp" %% "async-http-client-backend-cats" % sttpV
 
   val circe: Seq[ModuleID] = Seq(
     "io.circe" %% "circe-core",
@@ -93,10 +97,12 @@ object Dependencies {
     scalaLogging,
     ficus,
     cats,
+    catsEffect,
     enumeratum,
 
     javaxServlet,
     sttp,
+    sttpCats,
 
     googleEndpointsFramework,
     googleEndpointsManagementControl,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -27,7 +27,8 @@ object Settings {
     "-feature",
     "-encoding", "utf8",
     "-target:jvm-1.8",
-    "-language:postfixOps"
+    "-language:postfixOps",
+    "-Ypartial-unification"
   )
 
   //sbt assembly settings

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDao.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDao.scala
@@ -4,16 +4,19 @@ import java.util.logging.Logger
 
 import cats._
 import cats.implicits._
-import com.softwaremill.sttp.{Id, _}
+import com.softwaremill.sttp._
 import io.circe.generic.auto._
 import io.circe.parser._
 import org.broadinstitute.dsde.workbench.avram.model.AvramException
-import org.broadinstitute.dsde.workbench.avram.util.RestClient
+import org.broadinstitute.dsde.workbench.avram.util.{AvramResult, RestClient}
 
 class HttpSamDao(samUrl: String) extends SamDao with RestClient {
   private val log: Logger = Logger.getLogger(getClass.getName)
 
   override def getUserStatus(token: String): Either[AvramException, SamUserInfoResponse] = {
+    // Temporarily put sttp backend in implicit scope here instead of RestClient
+    implicit val backend = sttpBackend
+
     val request = buildAuthenticatedGetRequest(samUrl, "/register/user/v2/self/info", token)
     for {
       response <- request.send()
@@ -23,23 +26,17 @@ class HttpSamDao(samUrl: String) extends SamDao with RestClient {
     } yield userInfo
   }
 
+  override def queryAction(samResource: String, action: String, token: String): AvramResult[Boolean] = {
+    // Temporarily put sttp backend in implicit scope here instead of RestClient
+    implicit val backend = catsSttpBackend
+
+    val request = buildAuthenticatedGetRequest(samUrl, s"/api/resources/v1/entity-collection/$samResource/action/$action", token)
+    for {
+      response <- AvramResult.fromIO(request.send())
+      content <- AvramResult.fromEither(response.body leftMap responseToErrorResponse(response))
+    } yield content.toBoolean
+  }
+
   private def responseToErrorResponse(response: Response[String]): String => AvramException = error => AvramException(response.code, error)
   private def circeErrorToErrorResponse(e: io.circe.Error): AvramException = AvramException(500, e.getMessage)
-
-  // For the sake of comparison, this is what getUserStatus used to look like
-//  private def longhandResponseToEitherErrorOrUserInfo(response: Id[Response[String]]): Either[ErrorResponse, SamUserInfoResponse] = {
-//    response.body match {
-//      case Left(error: String) => Left(ErrorResponse(response.code, error))
-//      case Right(content: String) =>
-//        parse(content) match {
-//          case Left(error: ParsingFailure) => Left(ErrorResponse(500, error.message))
-//          case Right(json: Json) =>
-//            val result: Result[SamUserInfoResponse] = json.as[SamUserInfoResponse]
-//            result match {
-//              case Left(error: DecodingFailure) => Left(ErrorResponse(500, error.message))
-//              case Right(userInfo: SamUserInfoResponse) => Right(userInfo)
-//            }
-//        }
-//    }
-//  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/SamDao.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/SamDao.scala
@@ -1,9 +1,11 @@
 package org.broadinstitute.dsde.workbench.avram.dataaccess
 
 import org.broadinstitute.dsde.workbench.avram.model.AvramException
+import org.broadinstitute.dsde.workbench.avram.util.AvramResult
 
 trait SamDao {
   def getUserStatus(token: String): Either[AvramException, SamUserInfoResponse]
+  def queryAction(samResource: String, action: String, token: String): AvramResult[Boolean]
 }
 
 case class SamUserInfoResponse(userSubjectId: String, userEmail: String, enabled: Boolean)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/AvramResult.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/AvramResult.scala
@@ -1,0 +1,21 @@
+package org.broadinstitute.dsde.workbench.avram.util
+
+import cats.data.EitherT
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.avram.model.AvramException
+
+// Note: I'm unsatisfied with AvramResult as a name but I can't think of anything better. Suggestions welcome. -breilly
+object AvramResult {
+
+  def pure[A](a: A): AvramResult[A] = EitherT.pure(a)
+  def fromError[A](e: AvramException): AvramResult[A] = EitherT.left(IO(e))
+  def fromIO[A](io: IO[A]): AvramResult[A] = EitherT.right(io)
+  def fromEither[A](either: Either[AvramException, A]): AvramResult[A] = EitherT.fromEither[IO](either)
+
+  /**
+    * Invoke execution of computations represented by an AvramResult and produce the result value.
+    * This will throw an exception for any errors raised by the computation.
+    */
+  def unsafeRun[A](result: AvramResult[A]): A =
+    result.value.unsafeRunSync().fold(e => throw e, identity)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/RestClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/RestClient.scala
@@ -3,7 +3,9 @@ package org.broadinstitute.dsde.workbench.avram.util
 import java.net.URI
 import java.util.logging.Logger
 
-import com.softwaremill.sttp.{HttpURLConnectionBackend, Request, Uri, sttp}
+import cats.effect.IO
+import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
+import com.softwaremill.sttp.{HttpURLConnectionBackend, Id, Request, SttpBackend, Uri, sttp}
 
 /**
   * Helpful stuff for making rest calls using sttp (https://github.com/softwaremill/sttp).
@@ -11,7 +13,9 @@ import com.softwaremill.sttp.{HttpURLConnectionBackend, Request, Uri, sttp}
 trait RestClient {
   private val log: Logger = Logger.getLogger(getClass.getName)
 
-  implicit def sttpBackend = HttpURLConnectionBackend() // TODO: consider refactoring to allow use of SttpBackendStub in tests
+  // Temporarily don't put either of these in implicit scope so that functions can choose one
+  def sttpBackend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
+  def catsSttpBackend: SttpBackend[IO, Nothing] = AsyncHttpClientCatsBackend[IO]()
 
   def buildAuthenticatedGetRequest(url: String, path: String, token: String): Request[String, Nothing] = {
     sttp.auth.bearer(token).get(buildUri(url, path))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/package.scala
@@ -1,0 +1,12 @@
+package org.broadinstitute.dsde.workbench.avram
+
+import cats.data.EitherT
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.avram.model.AvramException
+
+package object util {
+  /**
+    * Convenience type that effectively represents IO[Either[ErrorResponse, A]]
+    */
+  type AvramResult[A] = EitherT[IO, AvramException, A]
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDaoSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDaoSpec.scala
@@ -1,8 +1,20 @@
 package org.broadinstitute.dsde.workbench.avram.dataaccess
 
 import org.broadinstitute.dsde.workbench.avram.model.AvramException
+import org.broadinstitute.dsde.workbench.avram.util.AvramResult.unsafeRun
+import org.mockserver.model.HttpResponse.response
 import org.scalatest.{FreeSpec, Matchers}
 
+/**
+  * These tests rely on the current MockSam which I'd like to deprecate. Understanding the tests
+  * requires understanding the behavior currently baked in to MockSam. While that behavior is pretty
+  * simple right now, I think it will become too tempting to reimplement somewhat complex Sam
+  * behavior in our mock. We should only be using a mock to test that Avram can make requests to Sam
+  * and correctly decode responses.
+  *
+  * The test cases in here should be migrated to a spec that uses a simpler mock Sam.
+  */
+@deprecated
 class HttpSamDaoSpec extends FreeSpec with Matchers with MockSam {
 
   override def samPort = 9999
@@ -21,6 +33,28 @@ class HttpSamDaoSpec extends FreeSpec with Matchers with MockSam {
 
       val expectedResponse = SamUserInfoResponse(subjectId, email, enabled = true)
       samDao.getUserStatus(token) shouldEqual Right(expectedResponse)
+    }
+  }
+}
+
+/**
+  * Test cases for making requests to Sam and correctly returning responses to Avram.
+  *
+  * TODO: Migrate test cases from HttpSamDaoSpec to here, remove existing HttpSamDaoSpec, and rename NewHttpSamDaoSpec to HttpSamDaoSpec
+  */
+class NewHttpSamDaoSpec extends FreeSpec with Matchers with SimpleMockSam {
+  override def samPort = 9999
+  lazy val samDao: SamDao = new HttpSamDao(mockSam.baseUrl)
+
+  "HttpSamDao" - {
+    "queryAction" - {
+      "should query sam and translate the response to a boolean" in {
+        val request = buildQueryActionRequest("sam-resource-123", "read", "token")
+        mockSam.when(request).respond(response("true"))
+        val result = samDao.queryAction("sam-resource-123", "read", "token")
+        unsafeRun(result) shouldEqual true
+        mockSam.verify(request)
+      }
     }
   }
 }


### PR DESCRIPTION
This PR introduces concepts from Rob's experimental FP refactor (#12) for the new code without refactoring the existing code. I did it this way for 2 reasons:

1. to avoid including changes that are unrelated to adding authorization
2. to allow a side-by-side comparison of the code

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
