### PR TITLE
Refactor/clean-up deprecated code after moving to AvramResult

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,6 +85,8 @@ object Dependencies {
     "io.circe" %% "circe-parser"
   ).map(_ % circeV)
 
+  val json4sNative = "org.json4s" %% "json4s-native" % "3.6.1" % "test"
+
   val rootDependencies = circe ++ Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
@@ -92,6 +94,7 @@ object Dependencies {
     jacksonDatabind,
     jacksonCore,
     jacksonScalaModule,
+    json4sNative,
 
     ravenLogback,
     scalaLogging,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramServlet.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramServlet.scala
@@ -55,7 +55,7 @@ trait AvramServlet {
   private def extractUserInfo(r: HttpServletRequest): Either[AvramException, SamUserInfoResponse] = {
     for {
       token <- extractBearerToken(r)
-      userInfo <- samDao.getUserStatus(token)
+      userInfo <- samDao.getUserStatus_deprecated(token) // TODO: migrate away from deprecated function
     } yield {
       userInfo
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramServlet.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramServlet.scala
@@ -46,16 +46,16 @@ trait AvramServlet {
 
     unsafeRun(writeBody, writeError, t => AvramException(500, s"Unhandled error", t)) {
       for {
-        userInfo <- AvramResult.fromEither(extractUserInfo(request))
+        userInfo <- extractUserInfo(request)
         result <- f(userInfo)
       } yield result
     }
   }
 
-  private def extractUserInfo(r: HttpServletRequest): Either[AvramException, SamUserInfoResponse] = {
+  private def extractUserInfo(r: HttpServletRequest): AvramResult[SamUserInfoResponse] = {
     for {
-      token <- extractBearerToken(r)
-      userInfo <- samDao.getUserStatus(token).value.unsafeRunSync()
+      token <- AvramResult.fromEither(extractBearerToken(r))
+      userInfo <- samDao.getUserStatus(token)
     } yield {
       userInfo
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramServlet.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/api/AvramServlet.scala
@@ -55,7 +55,7 @@ trait AvramServlet {
   private def extractUserInfo(r: HttpServletRequest): Either[AvramException, SamUserInfoResponse] = {
     for {
       token <- extractBearerToken(r)
-      userInfo <- samDao.getUserStatus_deprecated(token) // TODO: migrate away from deprecated function
+      userInfo <- samDao.getUserStatus(token).value.unsafeRunSync()
     } yield {
       userInfo
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDao.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDao.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.avram.dataaccess
 import java.util.logging.Logger
 
 import cats.implicits._
-import com.softwaremill.sttp.Response
 import io.circe.generic.auto._
 import io.circe.parser._
 import javax.servlet.http.HttpServletResponse

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDao.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDao.scala
@@ -13,37 +13,17 @@ import org.broadinstitute.dsde.workbench.avram.util.{AvramResult, RestClient}
 class HttpSamDao(samUrl: String) extends SamDao with RestClient {
   private val log: Logger = Logger.getLogger(getClass.getName)
 
-  // This function is deprecated and no longer has test coverage. Migrate to getUserStatus after merge of PR #22
-  override def getUserStatus_deprecated(token: String): Either[AvramException, SamUserInfoResponse] = {
-    // Temporarily put sttp backend in implicit scope here instead of RestClient
-    implicit val backend = sttpBackend
-
-    val request = buildAuthenticatedGetRequest(samUrl, "/register/user/v2/self/info", token)
-    for {
-      response <- request.send()
-      content <- response.body                 leftMap errorResponseToAvramException(response.code)
-      json <- parse(content)                   leftMap circeErrorToAvramException
-      userInfo <- json.as[SamUserInfoResponse] leftMap circeErrorToAvramException
-    } yield userInfo
-  }
-
   override def getUserStatus(token: String): AvramResult[SamUserInfoResponse] = {
-    // Temporarily put sttp backend in implicit scope here instead of RestClient
-    implicit val backend = catsSttpBackend
-
     val request = buildAuthenticatedGetRequest(samUrl, "/register/user/v2/self/info", token)
     for {
       response <- AvramResult.fromIO(request.send())
-      content <- AvramResult.fromEither(response.body leftMap responseToErrorResponse(response))
-      json <- AvramResult.fromEither(parse(content) leftMap circeErrorToErrorResponse)
-      userInfo <- AvramResult.fromEither(json.as[SamUserInfoResponse] leftMap circeErrorToErrorResponse)
+      content <- AvramResult.fromEither(response.body leftMap errorResponseToAvramException(response.code))
+      json <- AvramResult.fromEither(parse(content) leftMap circeErrorToAvramException)
+      userInfo <- AvramResult.fromEither(json.as[SamUserInfoResponse] leftMap circeErrorToAvramException)
     } yield userInfo
   }
 
   override def queryAction(samResource: String, action: String, token: String): AvramResult[Boolean] = {
-    // Temporarily put sttp backend in implicit scope here instead of RestClient
-    implicit val backend = catsSttpBackend
-
     val request = buildAuthenticatedGetRequest(samUrl, s"/api/resources/v1/entity-collection/$samResource/action/$action", token)
     for {
       response <- AvramResult.fromIO(request.send())

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/SamDao.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/SamDao.scala
@@ -4,7 +4,9 @@ import org.broadinstitute.dsde.workbench.avram.model.AvramException
 import org.broadinstitute.dsde.workbench.avram.util.AvramResult
 
 trait SamDao {
-  def getUserStatus(token: String): Either[AvramException, SamUserInfoResponse]
+  @deprecated("Use getUserStatus instead", "11/1/2018")
+  def getUserStatus_deprecated(token: String): Either[AvramException, SamUserInfoResponse]
+  def getUserStatus(token: String): AvramResult[SamUserInfoResponse]
   def queryAction(samResource: String, action: String, token: String): AvramResult[Boolean]
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/SamDao.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/SamDao.scala
@@ -4,8 +4,6 @@ import org.broadinstitute.dsde.workbench.avram.model.AvramException
 import org.broadinstitute.dsde.workbench.avram.util.AvramResult
 
 trait SamDao {
-  @deprecated("Use getUserStatus instead", "11/1/2018")
-  def getUserStatus_deprecated(token: String): Either[AvramException, SamUserInfoResponse]
   def getUserStatus(token: String): AvramResult[SamUserInfoResponse]
   def queryAction(samResource: String, action: String, token: String): AvramResult[Boolean]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/RestClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/avram/util/RestClient.scala
@@ -13,9 +13,7 @@ import com.softwaremill.sttp.{HttpURLConnectionBackend, Id, Request, SttpBackend
 trait RestClient {
   private val log: Logger = Logger.getLogger(getClass.getName)
 
-  // Temporarily don't put either of these in implicit scope so that functions can choose one
-  def sttpBackend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
-  def catsSttpBackend: SttpBackend[IO, Nothing] = AsyncHttpClientCatsBackend[IO]()
+  implicit def catsSttpBackend: SttpBackend[IO, Nothing] = AsyncHttpClientCatsBackend[IO]()
 
   def buildAuthenticatedGetRequest(url: String, path: String, token: String): Request[String, Nothing] = {
     sttp.auth.bearer(token).get(buildUri(url, path))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDaoSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDaoSpec.scala
@@ -6,47 +6,39 @@ import org.mockserver.model.HttpResponse.response
 import org.scalatest.{FreeSpec, Matchers}
 
 /**
-  * These tests rely on the current MockSam which I'd like to deprecate. Understanding the tests
-  * requires understanding the behavior currently baked in to MockSam. While that behavior is pretty
-  * simple right now, I think it will become too tempting to reimplement somewhat complex Sam
-  * behavior in our mock. We should only be using a mock to test that Avram can make requests to Sam
-  * and correctly decode responses.
-  *
-  * The test cases in here should be migrated to a spec that uses a simpler mock Sam.
-  */
-@deprecated
-class HttpSamDaoSpec extends FreeSpec with Matchers with MockSam {
-
-  override def samPort = 9999
-  lazy val samDao = new HttpSamDao(mockSam.baseUrl)
-
-  "HttpSamDao" - {
-    "should return 401 error when token is empty" in {
-      samDao.getUserStatus("") shouldEqual Left(AvramException(401, "Unauthorized"))
-    }
-
-    "should return valid user response for authenticated user" in {
-      val token = "test"
-      val subjectId = "123"
-      val email = "test@dummy.org"
-      mockSam.addValidAuthentication(token, subjectId, email)
-
-      val expectedResponse = SamUserInfoResponse(subjectId, email, enabled = true)
-      samDao.getUserStatus(token) shouldEqual Right(expectedResponse)
-    }
-  }
-}
-
-/**
   * Test cases for making requests to Sam and correctly returning responses to Avram.
   *
-  * TODO: Migrate test cases from HttpSamDaoSpec to here, remove existing HttpSamDaoSpec, and rename NewHttpSamDaoSpec to HttpSamDaoSpec
+  * This only tests that HttpSamDao can correctly handle the possible result _types_ (JSON, errors,
+  * etc.) from Sam, not every possible result. Once we know that Avram knows how to communicate with
+  * Sam, we can feed interesting test cases to Avram ourselves without using a mock server.
   */
-class NewHttpSamDaoSpec extends FreeSpec with Matchers with AvramResultSupport with SimpleMockSam {
+class HttpSamDaoSpec extends FreeSpec with Matchers with AvramResultSupport with MockSam {
   override def samPort = 9999
   lazy val samDao: SamDao = new HttpSamDao(mockSam.baseUrl)
 
   "HttpSamDao" - {
+    "getUserStatus" - {
+      "should handle 401 response when authorization fails" in {
+        val token = "test-token"
+        mockSam.when(buildUserStatusRequest(token)).respond(response("Unauthorized").withStatusCode(401))
+
+        // Sam response body is logged, not passed through to the Avram response
+        the [AvramException] thrownBy unsafeRun(samDao.getUserStatus(token)) should have (
+          'status (401),
+          'message ("Unauthorized")
+        )
+      }
+
+      "should handle user info response when authentication succeeds" in {
+        val token = "test-token"
+        val subjectId = "123"
+        val email = "test@dummy.org"
+        mockSam.when(buildUserStatusRequest(token)).respond(buildUserStatusResponse(subjectId, email))
+
+        unsafeRun(samDao.getUserStatus(token)) shouldEqual SamUserInfoResponse(subjectId, email, enabled = true)
+      }
+    }
+
     "queryAction" - {
       "should query sam and translate the response to a boolean" in {
         val request = buildQueryActionRequest("sam-resource-123", "read", "token")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDaoSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/avram/dataaccess/HttpSamDaoSpec.scala
@@ -20,7 +20,7 @@ class HttpSamDaoSpec extends FreeSpec with Matchers with AvramResultSupport with
     "getUserStatus" - {
       "should handle 401 response when authorization fails" in {
         val token = "test-token"
-        mockSam.when(buildUserStatusRequest(token)).respond(response("Unauthorized").withStatusCode(401))
+        mockSam.when(buildUserStatusRequest(token)).respond(response("Sam says go away").withStatusCode(401))
 
         // Sam response body is logged, not passed through to the Avram response
         the [AvramException] thrownBy unsafeRun(samDao.getUserStatus(token)) should have (


### PR DESCRIPTION
This cleans up `SamDao` and tests after the recent move to `AvramResult`.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
