### PR TITLE
Add logging config for slick

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <logger name="scala.slick" level="INFO" />
+</configuration>


### PR DESCRIPTION
Something I had locally but hadn't put it in a PR yet. Without this, we get a log of debug-level logging from slick.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
